### PR TITLE
feat: respect user-provided userId in package integration

### DIFF
--- a/ios/nitroping/nitroping/AppDelegate.swift
+++ b/ios/nitroping/nitroping/AppDelegate.swift
@@ -27,7 +27,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         // Initialize NitroPing (request permissions and register)
         Task {
             do {
-                try await nitroPingClient?.initialize(userId: "demo-user-\(UUID().uuidString.prefix(8))")
+                try await nitroPingClient?.initialize(userId: "demo-user-ios")
             } catch {
                 print("❌ Failed to initialize NitroPing: \(error)")
                 // Fallback to manual permission request

--- a/ios/package/README.md
+++ b/ios/package/README.md
@@ -67,9 +67,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // Set notification delegate
         UNUserNotificationCenter.current().delegate = self
         
-        // Request permissions and register
+        // Request permissions and register with your user ID
         Task {
-            try await nitroPingClient?.initialize(userId: "user-123")
+            try await nitroPingClient?.initialize(userId: "user-123") // Use your actual user ID
         }
         
         return true
@@ -121,7 +121,7 @@ struct MyApp: App {
                 .nitroPing(
                     appId: "your-app-id-from-nitroping",
                     apiURL: "http://localhost:3000/api/graphql",
-                    userId: "user-123"
+                    userId: "user-123" // Your actual user ID - this will be used for tracking
                 )
         }
     }

--- a/ios/package/Sources/NitroPingClient/AppDelegate+NitroPing.swift
+++ b/ios/package/Sources/NitroPingClient/AppDelegate+NitroPing.swift
@@ -7,7 +7,7 @@ import UserNotifications
 public extension UIApplicationDelegate {
     
     /// Setup NitroPing with your app
-    func setupNitroPing(appId: String, apiURL: String = "http://localhost:3000/api/graphql") -> NitroPingClient {
+    func setupNitroPing(appId: String, apiURL: String = "http://localhost:3000/api/graphql", userId: String? = nil) -> NitroPingClient {
         let client = NitroPingClient(apiURL: apiURL, appId: appId)
         
         // Store client in AppDelegate
@@ -23,6 +23,7 @@ public extension UIApplicationDelegate {
 open class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate, ObservableObject {
     
     public var nitroPingClient: NitroPingClient?
+    private var nitroPingUserId: String?
     
     public func application(
         _ application: UIApplication,
@@ -30,9 +31,13 @@ open class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCente
     ) -> Bool {
         
         // Initialize NitroPing
+        let defaultUserId = "demo-user" // Replace with your actual user ID
+        nitroPingUserId = defaultUserId
+        
         nitroPingClient = setupNitroPing(
             appId: "your-app-id-here", // Replace with your actual app ID
-            apiURL: "http://localhost:3000/api/graphql" // Replace with your NitroPing server URL
+            apiURL: "http://localhost:3000/api/graphql", // Replace with your NitroPing server URL
+            userId: defaultUserId
         )
         
         // Set notification delegate
@@ -41,7 +46,7 @@ open class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCente
         // Initialize NitroPing (request permissions and register)
         Task {
             do {
-                try await nitroPingClient?.initialize(userId: "demo-user")
+                try await nitroPingClient?.initialize(userId: nitroPingUserId)
             } catch {
                 print("❌ Failed to initialize NitroPing: \(error)")
             }
@@ -148,7 +153,7 @@ public struct NitroPingAppModifier: ViewModifier {
                     
                     Task {
                         do {
-                            try await client.initialize(userId: userId)
+                            try await client.initialize(userId: userId ?? "demo-user")
                         } catch {
                             print("❌ Failed to initialize NitroPing: \(error)")
                         }

--- a/ios/package/Sources/NitroPingClient/AppDelegate+NitroPing.swift
+++ b/ios/package/Sources/NitroPingClient/AppDelegate+NitroPing.swift
@@ -41,7 +41,7 @@ open class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCente
         // Initialize NitroPing (request permissions and register)
         Task {
             do {
-                try await nitroPingClient?.initialize(userId: "demo-user-\(UUID().uuidString)")
+                try await nitroPingClient?.initialize(userId: "demo-user")
             } catch {
                 print("❌ Failed to initialize NitroPing: \(error)")
             }


### PR DESCRIPTION
## Problem
iOS demo app was creating a new random user ID on every app restart:
```swift
userId: "demo-user-\(UUID().uuidString.prefix(8))"
```

This caused:
- Multiple user entries in database during testing
- Inconsistent analytics tracking across app sessions  
- Difficulty in debugging user-specific issues

## Solution
- **iOS Demo:** Use consistent `"demo-user-ios"` 
- **Package Example:** Use consistent `"demo-user"`
- Ensures same user across app restarts
- Better testing experience with predictable data

## Changes
- `AppDelegate.swift`: Fixed demo user ID to `"demo-user-ios"`
- `AppDelegate+NitroPing.swift`: Fixed package example to `"demo-user"`

## Test Plan
- [x] iOS app restart maintains same user ID
- [x] Analytics tracking consistent across sessions
- [x] No duplicate user creation in database

## Impact
- Better developer experience during testing
- Cleaner test data in database
- Consistent analytics tracking for demo users