### PR TITLE
fix(queues): avoid ':' in BullMQ job ids (fixes #32)

### DIFF
--- a/app/server/queues/notification.queue.ts
+++ b/app/server/queues/notification.queue.ts
@@ -73,7 +73,7 @@ export async function addSendNotificationJobs(data: SendNotificationJobData[]) {
 export async function addFanoutNotificationJob(data: FanoutNotificationJobData) {
   const queue = getNotificationQueue()
   return queue.add('fanout-notification', data, {
-    jobId: `fanout:${data.notificationId}`,
+    jobId: `fanout-${data.notificationId}`,
     attempts: 5,
     backoff: {
       type: 'exponential',

--- a/app/server/utils/notificationJobId.ts
+++ b/app/server/utils/notificationJobId.ts
@@ -11,10 +11,13 @@ interface ChannelJobShape {
   to: string
 }
 
+// BullMQ rejects custom job ids containing ':' (used as a Redis key separator),
+// throwing "Custom Id cannot contain :". Use '-' instead.
 export function getSendNotificationJobId(data: DeviceJobShape | ChannelJobShape) {
   if (data.deliveryMode === 'device') {
-    return `notification:${data.notificationId}:device:${data.deviceId}`
+    return `notification-${data.notificationId}-device-${data.deviceId}`
   }
 
-  return `notification:${data.notificationId}:channel:${data.channelId}:${data.to}`
+  const to = data.to.replace(/:/g, '-')
+  return `notification-${data.notificationId}-channel-${data.channelId}-${to}`
 }

--- a/app/tests/notification-queue.test.ts
+++ b/app/tests/notification-queue.test.ts
@@ -14,7 +14,7 @@ describe('getSendNotificationJobId', () => {
         title: 'Hello',
         body: 'World',
       },
-    })).toBe('notification:n1:device:d1')
+    })).toBe('notification-n1-device-d1')
   })
 
   it('builds deterministic ids for channel jobs', () => {
@@ -29,6 +29,21 @@ describe('getSendNotificationJobId', () => {
         title: 'Hello',
         body: 'World',
       },
-    })).toBe('notification:n1:channel:c1:foo@example.com')
+    })).toBe('notification-n1-channel-c1-foo@example.com')
+  })
+
+  it('sanitizes colons in channel "to" field (e.g. Web Push endpoints)', () => {
+    expect(getSendNotificationJobId({
+      deliveryMode: 'channel',
+      notificationId: 'n1',
+      appId: 'a1',
+      channelId: 'c1',
+      to: 'https://fcm.googleapis.com/fcm/send/abc',
+      channelType: 'PUSH',
+      payload: {
+        title: 'Hello',
+        body: 'World',
+      },
+    })).not.toContain(':')
   })
 })


### PR DESCRIPTION
## Summary

Fixes #32 — `sendNotification` always fails with `Custom Id cannot contain :`.

BullMQ rejects custom `jobId`s containing `:` (it's the reserved Redis key separator). The notification queue was building ids with colons:

- \`fanout:\${data.notificationId}\` in \`addFanoutNotificationJob\`
- \`notification:\${notificationId}:device:\${deviceId}\` and \`notification:\${notificationId}:channel:\${channelId}:\${to}\` in \`getSendNotificationJobId\`

For channel/Web Push jobs, \`to\` is also an endpoint URL (\`https://fcm.googleapis.com/...\`) — so colons leak in from there too.

## Fix

- Replace \`:\` with \`-\` as the separator in all custom job ids.
- Sanitize colons out of the channel \`to\` segment before composing the id.
- Update existing tests and add one that verifies a URL-shaped \`to\` never leaks a \`:\` into the id.

## Test plan

- [x] \`pnpm test\` passes locally for the updated \`notification-queue.test.ts\`
- [ ] Manual: \`createApp\` → \`configureWebPush\` → \`registerDevice\` (web) → \`sendNotification { channelType: PUSH }\` — previously failed with \`Custom Id cannot contain :\`, now succeeds and delivers.

Determinism (same id for same \`(notificationId, deviceId)\` / \`(notificationId, channelId, to)\` pair) is preserved, so BullMQ's dedup behavior is unchanged.